### PR TITLE
Feat: add version flag to CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,8 +12,9 @@ import (
 var defaultMessage = "feat: initialize project"
 
 var rootCmd = &cobra.Command{
-	Use:   "gaia [commit message]",
-	Short: "Modify the first commit in a git repository",
+	Use:     "gaia [commit message]",
+	Version: "1.2.0",
+	Short:   "Modify the first commit in a git repository",
 	Long: `A CLI tool that checks if the current directory is a git repository
 and updates the very first commit with a new commit message.
 


### PR DESCRIPTION
# Description

Add `--version` / `-v` flag to the `gaia` CLI by setting the `Version` field on the root Cobra command. Bumps the version string to `1.2.0`.

## Related Issue(s)

<!-- If this pull request resolves any open issue(s), mention them here -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have tested my changes locally
- [x] I have added appropriate documentation or updated existing documentation
- [x] My code follows the project's coding conventions and style guidelines
- [x] All new and existing tests passed locally
- [x] I have reviewed my own code and ensured it is ready for review

## Screenshots (if applicable)

```
$ gaia --version
gaia version 1.2.0

$ gaia -v
gaia version 1.2.0
```

## Additional Notes

Cobra's built-in `Version` field automatically wires up both `--version` and `-v` flags with no extra code required.
